### PR TITLE
Fix error: too few arguments to function ‘SZ_compress_args2’

### DIFF
--- a/src/algo/algo-sz.dtype.c
+++ b/src/algo/algo-sz.dtype.c
@@ -73,7 +73,7 @@ int scil_sz_compress_<DATATYPE>(const scil_context_t* ctx,
   //printf("Running SZ: with %d %f %f\n", mode, abstol, reltol);
 
   int ret;
-  ret = SZ_compress_args2(SZ_<DATATYPE_UPPER>, source, dest, & size, mode, abstol, reltol, 0, dims->length[3], dims->length[2], dims->length[1], dims->length[0]);
+  ret = SZ_compress_args2(SZ_<DATATYPE_UPPER>, source, dest, & size, mode, abstol, reltol, 0.0, 0, 0, dims->length[3], dims->length[2], dims->length[1], dims->length[0]);
   //printf("Returns: %d\n", size);
   if (ret == 0){
     *dest_size = size;

--- a/src/test/sz.c
+++ b/src/test/sz.c
@@ -7,7 +7,7 @@
 int main(void){
   size_t buff_size = SIZE*sizeof(double);
   double * data = malloc(buff_size);
-  int out_size;
+  size_t out_size;
 
   for(int i=0; i < SIZE; i++){
     data[i] = i;
@@ -36,7 +36,7 @@ int main(void){
 
   SZ_Init_Params(& p);
   //SZ_Init("sz.config");
-  int ret = SZ_compress_args2(SZ_DOUBLE, data, out_buff, & out_size, ABS, 10.0, 0.0,  0,0,0,0, SIZE);
+  int ret = SZ_compress_args2(SZ_DOUBLE, data, out_buff, & out_size, ABS, 10.0, 0.0,  0.0,0,0,0,0,0, SIZE);
   printf("%d %d\n", ret, out_size);
 
   double * result = malloc(buff_size);


### PR DESCRIPTION
Die beiden neuen Parameter pwrBoundRatio und pwrType von SZ_compress_args2() sind nur von Bedeutung falls "errBoundMode==PW_REL", wir verwenden aber bislang nur REL, ABS oder ABS_AND_REL